### PR TITLE
Update API and fix 0 kill error

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: PvPLevels
 author: corytortoise
 main: corytortoise\PvPLevels\Main
 version: "1.0"
-api: [2.0.0, 3.0.0-ALPHA9]
+api: [2.0.0, 3.0.0-ALPHA9, 3.0.0-ALPHA11]
 description: Stores PvP stats and enables leveling for kills.
 
 commands:

--- a/src/corytortoise/PvPLevels/Main.php
+++ b/src/corytortoise/PvPLevels/Main.php
@@ -1,7 +1,7 @@
 <?php
 
    namespace corytortoise\PvPLevels;
-	
+
    use pocketmine\Player;
    use pocketmine\Server;
    use pocketmine\plugin\PluginBase;
@@ -18,12 +18,12 @@
 
    use corytortoise\PvPLevels\EventListener;
    use corytortoise\PvPLevels\PlayerData;
-	
+
 	  class Main extends PluginBase {
 
       private $cfg;
       private $playerData = array();
-		
+
       public function onEnable() {
             $this->saveDefaultConfig();
             $this->reloadConfig();
@@ -59,12 +59,12 @@
           $this->getData($player->getName())->addDeath();
           return;
         }
-  
+
         public function getData($name) {
           return new PlayerData($this, $name);
         }
 
-        public function onCommand(CommandSender $sender, Command $command, $label, array $args) {
+        public function onCommand(CommandSender $sender, Command $command, string $label, array $args) : bool {
           if(strtolower($command->getName()) == "pvpstats") {
             if($sender instanceof Player) {
               if(isset($args[0])) {

--- a/src/corytortoise/PvPLevels/PlayerData.php
+++ b/src/corytortoise/PvPLevels/PlayerData.php
@@ -6,7 +6,7 @@
   use pocketmine\utils\Config;
 
   use corytortoise\PvPLevels\Main;
-  
+
     class PlayerData {
 
       private $plugin;
@@ -46,7 +46,12 @@
     }
 
     public function getKdr() {
-      return $this->kills / $this->deaths;
+      if ($this->kills > 0){
+        return $this->kills / $this->deaths;
+      }
+      else{
+        return 0;
+      }
     }
 
     public function getLevel() {


### PR DESCRIPTION
Now works with API 3.0.0ALPHA11 and fix division-by-zero error on players with 0 kills.